### PR TITLE
adc/drivers/iio/adc: Added enable and input loopback functionality

### DIFF
--- a/drivers/iio/adc/iio_ad5592r_s.c
+++ b/drivers/iio/adc/iio_ad5592r_s.c
@@ -13,147 +13,173 @@
 const int CHANEL_0 = 0, CHANEL_1 = 1, CHANEL_2 = 2;
 const int CHANEL_3 = 3, CHANEL_4 = 4, CHANEL_5 = 5;
 
+struct iio_ad5592r_s_st {
+	bool reg_select;
+	int chan_val[6];
+};
 
 static int iio_ad5592r_s_read_raw(struct iio_dev *indio_dev,
-			struct iio_chan_spec const *chan,
-			int *val,
-			int *val2,
-			long mask)
+				  struct iio_chan_spec const *chan, int *val,
+				  int *val2, long mask)
 {
-    switch(mask){
-        case IIO_CHAN_INFO_RAW:
-            switch(chan->channel){
-                case CHANEL_0:     
-                    *val = 67;
-                    break;
-                case CHANEL_1:
-                    *val = 76;
-                    break;
-                case CHANEL_2:   
-                    *val = 420;
-                    break;
-                case CHANEL_3:    
-                    *val = 69;
-                    break;
-                case CHANEL_4: 
-                    *val = 96;
-                    break;
-                case CHANEL_5:  
-                    *val = 42067;
-                    break;
-                default: 
-                    return -EINVAL;
-            }
-            return IIO_VAL_INT;
-        default:
-            return -EINVAL;
-    }
+	struct iio_ad5592r_s_st *st = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		if (!st->reg_select) {
+			switch (chan->channel) {
+			case CHANEL_0:
+				*val = st->chan_val[CHANEL_0];
+				break;
+			case CHANEL_1:
+				*val = st->chan_val[CHANEL_1];
+                                break;
+			case CHANEL_2:
+				*val = st->chan_val[CHANEL_2];
+                                break;
+			case CHANEL_3:
+				*val = st->chan_val[CHANEL_3];
+                                break;
+			case CHANEL_4:
+				*val = st->chan_val[CHANEL_4];
+                                break;
+			case CHANEL_5:
+				*val = st->chan_val[CHANEL_5];
+                                break;
+			default:
+				return -EINVAL;
+			}
+			return IIO_VAL_INT;
+		} else
+			return -EINVAL;
+	case IIO_CHAN_INFO_ENABLE:
+		*val = st->reg_select;
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
+	}
 }
 
 static int iio_ad5592r_s_write_raw(struct iio_dev *indio_dev,
-			 struct iio_chan_spec const *chan,
-			 int val,
-			 int val2,
-			 long mask)
+				   struct iio_chan_spec const *chan, int val,
+				   int val2, long mask)
 {
-    switch(mask){
-        case IIO_CHAN_INFO_RAW:
-            switch(chan->channel){
-                case CHANEL_0:     
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 0");
-                    break;
-                case CHANEL_1:
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 1");
-                    break;
-                case CHANEL_2:   
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 2");
-                    break;
-                case CHANEL_3:    
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 3");
-                    break;
-                case CHANEL_4: 
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 4");
-                    break;
-                case CHANEL_5:  
-                    dev_info(&indio_dev->dev,"Trying to write to chanel 5");
-                    break;
-                default: 
-                    return -EINVAL;
-            }
-            return 0;
-        default:
-            return -EINVAL;
-    }
+	struct iio_ad5592r_s_st *st = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		if (!st->reg_select) {
+			switch (chan->channel) {
+			case CHANEL_0:
+				dev_info(&indio_dev->dev, "Trying to write to chanel 0");
+				st->chan_val[CHANEL_0] = val;
+				return 0;
+			case CHANEL_1:
+				dev_info(&indio_dev->dev,"Trying to write to chanel 1");
+				st->chan_val[CHANEL_1] = val;
+				return 0;
+			case CHANEL_2:
+				dev_info(&indio_dev->dev, "Trying to write to chanel 2");
+				st->chan_val[CHANEL_2] = val;
+				return 0;
+			case CHANEL_3:
+				dev_info(&indio_dev->dev, "Trying to write to chanel 3");
+				st->chan_val[CHANEL_3] = val;
+				return 0;
+			case CHANEL_4:
+				dev_info(&indio_dev->dev, "Trying to write to chanel 4");
+				st->chan_val[CHANEL_4] = val;
+				return 0;
+			case CHANEL_5:
+				dev_info(&indio_dev->dev, "Trying to write to chanel 5");
+				st->chan_val[CHANEL_5] = val;
+				return 0;
+			default:
+				return -EINVAL;
+			}
+		} else
+			return -EINVAL;
+	case IIO_CHAN_INFO_ENABLE:
+		st->reg_select = val ? 1 : 0;
+		return 0;
+	default:
+		return -EINVAL;
+	}
 }
 
 static const struct iio_chan_spec iio_ad5592r_s_chanels[] = {
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_0,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_1,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_2,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_3,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_4,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = CHANEL_5,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    }
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_0,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_1,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_2,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_3,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_4,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = CHANEL_5,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	}
 };
 
 static const struct iio_info iio_ad5592r_s_info = {
-    .read_raw = &iio_ad5592r_s_read_raw,
-    .write_raw = &iio_ad5592r_s_write_raw,
+	.read_raw = &iio_ad5592r_s_read_raw,
+	.write_raw = &iio_ad5592r_s_write_raw,
 };
 
+static int iio_ad5592r_s_probe(struct spi_device *spi)
+{
+	struct iio_dev *indio_dev;
+	struct iio_ad5592r_s_st *st;
 
-static int iio_ad5592r_s_probe(struct spi_device *spi){
-    struct iio_dev *indio_dev;
-    
-    indio_dev = devm_iio_device_alloc(&spi->dev,0);
-    
-    indio_dev->name ="iio_ad5592r_s";
-    indio_dev->info = &iio_ad5592r_s_info;
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 
-    indio_dev->channels = iio_ad5592r_s_chanels;
-    indio_dev->num_channels = 6;
-    
-    return devm_iio_device_register(&spi->dev,indio_dev);
+	indio_dev->name = "iio_ad5592r_s";
+	indio_dev->info = &iio_ad5592r_s_info;
 
+	indio_dev->channels = iio_ad5592r_s_chanels;
+	indio_dev->num_channels = ARRAY_SIZE(iio_ad5592r_s_chanels);
+
+	st = iio_priv(indio_dev);
+	st->reg_select = 1;
+	memset(st->chan_val, 0, sizeof(st->chan_val));
+
+	return devm_iio_device_register(&spi->dev, indio_dev);
 }
 
-struct spi_driver iio_ad5592r_s_driver = {
-    .driver = {
-        .name = "iio_ad5592r_s"
-    },
-    .probe = iio_ad5592r_s_probe
-};
+struct spi_driver iio_ad5592r_s_driver = { .driver = { .name = "iio_ad5592r_s" },
+					   .probe = iio_ad5592r_s_probe };
 module_spi_driver(iio_ad5592r_s_driver);
-
 
 MODULE_AUTHOR("Papp Richard <pappr805@gmail.com>");
 MODULE_DESCRIPTION("ADC driver for COraz7s board");


### PR DESCRIPTION
## PR Description

Added six channel common enable functionality. Added loopback of writen inputs at chanel read.
adc/iio_ad5592r_s.c:-Added a private struct for enable and chanel value vector
-Associated the structure to indio_dev
-Implemented reset functionality with an if before outputing/inputing each channel
-Implemented loopback, by saving/reading to/from channel value vector -Initialize reset with '1', and value vector with '0'

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
