### PR TITLE
 drivers : iio : adc : added a struct with 2 component and initialize it

### DIFF
--- a/drivers/iio/adc/ad5592r_s.c
+++ b/drivers/iio/adc/ad5592r_s.c
@@ -10,24 +10,37 @@
 #include <linux/spi/spi.h>
 #include <linux/iio/iio.h>
 
+struct iio_adc_placa_st {
+	bool reg_select;
+	int chan_val[6];
+};
+
 static int iio_adc_placa_read_raw(struct iio_dev *indio_dev,
-				struct iio_chan_spec const *chan, int *val,
-				int *val2, long mask)
+				  struct iio_chan_spec const *chan, int *val,
+				  int *val2, long mask)
 {
+	struct iio_adc_placa_st *st = iio_priv(indio_dev);
+
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
-		if (chan->channel == 0)
-			*val = 0;
-		if (chan->channel == 1)
-            *val = 1;
-        if (chan->channel == 2)
-            *val = 2;
-        if (chan->channel == 3)
-            *val = 3;
-        if (chan->channel == 4)
-            *val = 4;
-        if (chan->channel == 5)
-            *val = 5;
+		if(!st->reg_select){
+			if (chan->channel == 0)
+				*val = st->chan_val[0];
+			if (chan->channel == 1)
+				*val = st->chan_val[1];
+			if (chan->channel == 2)
+				*val = st->chan_val[2];
+			if (chan->channel == 3)
+				*val = st->chan_val[3];
+			if (chan->channel == 4)
+				*val = st->chan_val[4];
+			if (chan->channel == 5)
+				*val = st->chan_val[5];
+			return IIO_VAL_INT;
+		}else
+			return -EINVAL;
+	case IIO_CHAN_INFO_ENABLE:
+		*val = st->reg_select;
 		return IIO_VAL_INT;
 	default:
 		return -EINVAL;
@@ -35,23 +48,52 @@ static int iio_adc_placa_read_raw(struct iio_dev *indio_dev,
 }
 
 static int iio_adc_placa_write_raw(struct iio_dev *indio_dev,
-				 struct iio_chan_spec const *chan, int val,
-				 int val2, long mask)
+				   struct iio_chan_spec const *chan, int val,
+				   int val2, long mask)
 {
+	struct iio_adc_placa_st *st = iio_priv(indio_dev);
+
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
-		if (chan->channel == 0)
-			dev_info(&indio_dev->dev, "Trying to write channel 0");
-		if (chan->channel == 1)
-			dev_info(&indio_dev->dev, "Trying to write channel 1");
-        if (chan->channel == 2)
-			dev_info(&indio_dev->dev, "Trying to write channel 2");
-        if (chan->channel == 3)
-			dev_info(&indio_dev->dev, "Trying to write channel 3");
-        if (chan->channel == 4)
-			dev_info(&indio_dev->dev, "Trying to write channel 4");
-        if (chan->channel == 5)
-			dev_info(&indio_dev->dev, "Trying to write channel 5");	
+		if(!st->reg_select){
+			if (chan->channel == 0){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 0");
+				st->chan_val[0] = val;
+			}
+			if (chan->channel == 1){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 1");
+				st->chan_val[1] = val;
+			}
+			if (chan->channel == 2){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 2");
+				st->chan_val[2] = val;
+			}
+			if (chan->channel == 3){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 3");
+				st->chan_val[3] = val;
+			}
+			if (chan->channel == 4){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 4");
+				st->chan_val[4] = val;
+			}
+			if (chan->channel == 5){
+				dev_info(&indio_dev->dev, 
+					"Trying to write channel 5");
+				st->chan_val[5] = val;
+			}
+			return 0;
+		}else
+			return -EINVAL;
+	case IIO_CHAN_INFO_ENABLE:
+		if(val)
+			st->reg_select = true;
+		else
+			st->reg_select = false;	
 		return 0;
 	default:
 		return -EINVAL;
@@ -64,58 +106,70 @@ static const struct iio_chan_spec iio_adc_placa_channels[] = {
 		.channel = 0,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	},
 	{
 		.type = IIO_VOLTAGE,
 		.channel = 1,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	},
-    {
+	{
 		.type = IIO_VOLTAGE,
 		.channel = 2,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	},
-    {
+	{
 		.type = IIO_VOLTAGE,
 		.channel = 3,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	},
-    {
+	{
 		.type = IIO_VOLTAGE,
 		.channel = 4,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	},
-    {
+	{
 		.type = IIO_VOLTAGE,
 		.channel = 5,
 		.indexed = 1,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
 	}
 };
 
 static const struct iio_info iio_adc_placa_info = {
-    .read_raw = &iio_adc_placa_read_raw,
-    .write_raw = &iio_adc_placa_write_raw
+	.read_raw = &iio_adc_placa_read_raw,
+	.write_raw = &iio_adc_placa_write_raw
 };
 
 ///Tot timpul se incepe cu functia de probe
 
-///folosim static pentru ca linux e destul de mare si de vast si sunt sanse sa scrie 2 persoane cu acelasi nume. si ca sa fim siguri
+///folosim static pentru ca linux e destul de mare si de vast si sunt sanse sa 
+///scrie 2 persoane cu acelasi nume. si ca sa fim siguri
 ///ca ne apelam functia noastra o scriem static.
 static int iio_adc_placa_probe(struct spi_device *spi)
 {
 	struct iio_dev *indio_dev;
 
-	indio_dev = devm_iio_device_alloc(&spi->dev, 0);
+	struct iio_adc_placa_st *st;
 
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
+
+	st = iio_priv(indio_dev);
+	memset(st->chan_val, 0, sizeof(st->chan_val));
+	st->reg_select = true;
 	indio_dev->name = "iio_adc_placa";
 	indio_dev->info = &iio_adc_placa_info;
-    indio_dev->channels = iio_adc_placa_channels;
-	indio_dev->num_channels = 6;
+	indio_dev->channels = iio_adc_placa_channels;
+	indio_dev->num_channels = ARRAY_SIZE(iio_adc_placa_channels);
 
 	return devm_iio_device_register(&spi->dev, indio_dev);
 }


### PR DESCRIPTION
## PR Description

    -Added a struct with 2 component, first is an enable that activate or
    desactivate reading from adc, the second one is an array where we
    read some value from the keybord
    -Modify the read and write function to use the new structure with
    their capabilities.
    -Initialize the structure component in probe function

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
