### PR TITLE
drivers: iio: adc: add private structure and channel enable functiona…

### DIFF
--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -53,6 +53,7 @@ obj-$(CONFIG_ADI_AXI_ADC) += adi-axi-adc.o
 obj-$(CONFIG_AD9963) += ad9963.o
 obj-$(CONFIG_ADAQ8092) += adaq8092.o
 obj-$(CONFIG_ADM1177) += adm1177.o
+obj-$(CONFIG_AD5592R_S) += ad5592r_s.o
 
 cf_axi_adc-y := cf_axi_adc_core.o
 obj-$(CONFIG_CF_AXI_ADC) += cf_axi_adc.o

--- a/drivers/iio/adc/ad5592r_s.c
+++ b/drivers/iio/adc/ad5592r_s.c
@@ -9,17 +9,179 @@
  #include <linux/spi/spi.h>
  #include <linux/iio/iio.h>
 
- static const struct iio_info iio_adc_info = {
+struct iio_adc5592rs_st {
+        int reg_select;
+        int chan_val[6];
+};
 
+static int iio_adc5592rs_read_raw(struct iio_dev *indio_dev,
+                          struct iio_chan_spec const *chan,
+                          int *val,
+                          int *val2,
+                          long mask)
+ 
+{ 
+   struct iio_adc5592rs_st *st = iio_priv(indio_dev);
+
+      switch (mask){
+            case IIO_CHAN_INFO_RAW:
+              if (!st->reg_select){
+               switch (chan->channel) {
+                  case 0:
+                     *val = st->chan_val[0];
+                     break;
+                  case 1:
+                     *val = st->chan_val[1];
+                     break;
+                  case 2:
+                     *val = st->chan_val[2];
+                     break;
+                  case 3:
+                     *val = st->chan_val[3];
+                     break;
+                  case 4:
+                     *val = st->chan_val[4];
+                     break;
+                  case 5:
+                     *val = st->chan_val[5];
+                     break;
+                  default:
+                     return -EINVAL;
+                  }
+                }
+                return IIO_VAL_INT;
+
+            case IIO_CHAN_INFO_ENABLE:
+                *val = st->reg_select;
+
+                  return IIO_VAL_INT;
+            default:
+                  return -EINVAL;
+        }
+}
+
+static int iio_adc5592rs_write_raw(struct iio_dev *indio_dev,
+                          struct iio_chan_spec const *chan,
+                          int val,
+                          int val2,
+                          long mask)
+
+{
+      struct iio_adc5592rs_st *st = iio_priv(indio_dev);
+        
+      switch (mask) {
+        case IIO_CHAN_INFO_RAW:
+                if (!st->reg_select) {
+                switch (chan->channel) {
+                  case 0:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 0");
+                    st->chan_val[0] = val;
+                  break;
+                  case 1:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 1");
+                    st->chan_val[1] = val;
+                  break;
+                  case 2:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 2");
+                    st->chan_val[2] = val;
+                  break;
+                  case 3:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 3");
+                    st->chan_val[3] = val;
+                  break;
+                  case 4:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 4");
+                    st->chan_val[4] = val;
+                  break;
+                  case 5:
+                    dev_info(&indio_dev->dev, "Trying to write to channel 5");
+                    st->chan_val[5] = val;
+                  break;
+                  default:
+                    return -EINVAL;
+                }
+                return 0;
+                } 
+                else 
+                   return -EINVAL;
+                
+                case IIO_CHAN_INFO_ENABLE:
+                        st->reg_select = val ? 1 : 0;
+                        return 0;
+
+                default:
+                   return -EINVAL;
+        }
+}
+
+static const struct iio_chan_spec iio_adc5592rs_channels[] = {
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 0,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 1,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 2,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 3,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 4,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+
+      {
+         .type = IIO_VOLTAGE,
+         .channel = 5,
+         .indexed = 1,
+         .info_mask_separate = BIT(IIO_CHAN_INFO_RAW), 
+         .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+      },
+};
+
+ static const struct iio_info iio_adc_info = {
+      .read_raw = &iio_adc5592rs_read_raw,
+      .write_raw = &iio_adc5592rs_write_raw,
  };
 
  static int iio_adc_probe(struct spi_device *spi){
     struct iio_dev *indio_dev;
+    struct iio_adc5592rs_st *st;
 
-    indio_dev = devm_iio_device_alloc(&spi->dev, 0);
-
+    indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
+    
+    st = iio_priv(indio_dev);
+    st->reg_select = 1;
+    memset(&st->chan_val, 0, sizeof(st->chan_val));
     indio_dev->name = "iio_adc";
     indio_dev->info = &iio_adc_info;
+    indio_dev->channels = iio_adc5592rs_channels;
+    indio_dev->num_channels = 6;
 
     return devm_iio_device_register(&spi->dev,indio_dev);
  }


### PR DESCRIPTION
## PR Description
Added iio_adc5592rs_st private state structure to hold channel values and enable status. 
Added IIO_CHAN_INFO_ENABLE handling to read_raw and write_raw callbacks to control device state. 
Added dynamic channel value storage in private state during raw write operations. 
Added array initialization for channels and switched channel count calculation to ARRAY_SIZE.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
