### PR TITLE
drivers: iio: adc: add enable control and loopback for AD5592R

### DIFF
--- a/drivers/iio/adc/ad5592r_s.c
+++ b/drivers/iio/adc/ad5592r_s.c
@@ -9,15 +9,32 @@
 #include <linux/spi/spi.h>
 #include <linux/iio/iio.h>
 
+#define AD5592R_S_NUM_CHANNELS	6
+
+struct ad5592r_s_state {
+	int reg_select;
+	int chan_val[AD5592R_S_NUM_CHANNELS];
+};
+
 static int ad5592r_s_read_raw(struct iio_dev *indio_dev,
 			      const struct iio_chan_spec *chan,
 			      int *val,
 			      int *val2,
 			      long mask)
 {
+	struct ad5592r_s_state *st = iio_priv(indio_dev);
+
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
-		*val = chan->channel * 100;
+		if (st->reg_select)
+			return -EINVAL;
+
+		*val = st->chan_val[chan->channel];
+
+		return IIO_VAL_INT;
+
+	case IIO_CHAN_INFO_ENABLE:
+		*val = st->reg_select;
 
 		return IIO_VAL_INT;
 
@@ -32,11 +49,23 @@ static int ad5592r_s_write_raw(struct iio_dev *indio_dev,
 			       int val2,
 			       long mask)
 {
+	struct ad5592r_s_state *st = iio_priv(indio_dev);
+
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
+		if (st->reg_select)
+			return -EINVAL;
+
+		st->chan_val[chan->channel] = val;
+
 		dev_info(&indio_dev->dev,
-			 "Try to write value %d to channel %d\n",
+			 "Write value %d to channel %d\n",
 			 val, chan->channel);
+
+		return 0;
+
+	case IIO_CHAN_INFO_ENABLE:
+		st->reg_select = val ? 1 : 0;
 
 		return 0;
 
@@ -52,6 +81,8 @@ static int ad5592r_s_write_raw(struct iio_dev *indio_dev,
 		.channel = (_channel),			\
 		.info_mask_separate =			\
 			BIT(IIO_CHAN_INFO_RAW),		\
+		.info_mask_shared_by_all =		\
+			BIT(IIO_CHAN_INFO_ENABLE),	\
 	}
 
 static const struct iio_chan_spec ad5592r_s_channels[] = {
@@ -71,10 +102,16 @@ static const struct iio_info ad5592r_s_info = {
 static int ad5592r_s_probe(struct spi_device *spi)
 {
 	struct iio_dev *indio_dev;
+	struct ad5592r_s_state *st;
 
-	indio_dev = devm_iio_device_alloc(&spi->dev, 0);
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (!indio_dev)
 		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+
+	st->reg_select = 1;
+	memset(st->chan_val, 0, sizeof(st->chan_val));
 
 	indio_dev->name = "ad5592r_s";
 	indio_dev->info = &ad5592r_s_info;


### PR DESCRIPTION
Add shared enable control for the ADC channels
Store written values for all six channels
Return stored values through raw reads
Allocate private driver state for channel data

## PR Description

Add shared enable control for the ADC channels
Store written values for all six channels
Return stored values through raw reads
Allocate private driver state for channel data

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ X ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ X ] I have conducted a self-review of my own code changes
- [ X ] I have compiled my changes, including the documentation
- [ X ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
