### PR TITLE
drivers/iio/adc: Add enable and loopback for AD5592R

### DIFF
--- a/drivers/iio/adc/iio_ad5592r_s.c
+++ b/drivers/iio/adc/iio_ad5592r_s.c
@@ -10,21 +10,35 @@
  #include <linux/spi/spi.h>
  #include <linux/iio/iio.h>
 
+  struct iio_ad5592r_st {
+        int reg_select;
+        int chan_val[6];
+ };
+
  static int iio_ad5592r_read_raw(struct iio_dev *indio_dev,
                                  struct iio_chan_spec const *chan,
                                  int *val, int *val2, long mask)
                                  {
+                                    struct iio_ad5592r_st *st = iio_priv(indio_dev);
                                     switch (mask) {
                                        case IIO_CHAN_INFO_RAW:
+                                          if(!st->reg_select) {
                                              switch(chan->channel) {
-                                                case 0: *val = 0; break;
-                                                case 1: *val = 1; break;
-                                                case 2: *val = 2; break;
-                                                case 3: *val = 3; break;
-                                                case 4: *val = 4; break;
-                                                case 5: *val = 5; break;
+                                                case 0: *val = st->chan_val[0]; break;
+                                                case 1: *val = st->chan_val[1]; break;
+                                                case 2: *val = st->chan_val[2]; break;
+                                                case 3: *val = st->chan_val[3]; break;
+                                                case 4: *val = st->chan_val[4]; break;
+                                                case 5: *val = st->chan_val[5]; break;
                                                 default: return -EINVAL;
                                              }
+                                             return IIO_VAL_INT;
+                                          }
+                                          else {
+                                             return -EINVAL;
+                                          }
+                                       case IIO_CHAN_INFO_ENABLE:
+                                             *val = st->reg_select;
                                              return IIO_VAL_INT;
                                        default:
                                              return -EINVAL;
@@ -37,17 +51,25 @@
                                  int val2,
                                  long mask)
  {
+   struct iio_ad5592r_st *st = iio_priv(indio_dev);
    switch (mask) {
       case IIO_CHAN_INFO_RAW:
+         if(!st->reg_select) {
          switch(chan->channel) {
-            case 0: dev_info(&indio_dev->dev, "Trying to write to channel 0"); return 0;
-            case 1: dev_info(&indio_dev->dev, "Trying to write to channel 1"); return 0;
-            case 2: dev_info(&indio_dev->dev, "Trying to write to channel 2"); return 0;
-            case 3: dev_info(&indio_dev->dev, "Trying to write to channel 3"); return 0;
-            case 4: dev_info(&indio_dev->dev, "Trying to write to channel 4"); return 0;
-            case 5: dev_info(&indio_dev->dev, "Trying to write to channel 5"); return 0;
+            case 0: dev_info(&indio_dev->dev, "Trying to write to channel 0"); st->chan_val[0] = val; return 0;
+            case 1: dev_info(&indio_dev->dev, "Trying to write to channel 1"); st->chan_val[1] = val; return 0;
+            case 2: dev_info(&indio_dev->dev, "Trying to write to channel 2"); st->chan_val[2] = val; return 0;
+            case 3: dev_info(&indio_dev->dev, "Trying to write to channel 3"); st->chan_val[3] = val; return 0;
+            case 4: dev_info(&indio_dev->dev, "Trying to write to channel 4"); st->chan_val[4] = val; return 0;
+            case 5: dev_info(&indio_dev->dev, "Trying to write to channel 5"); st->chan_val[5] = val; return 0;
             default: return -EINVAL;
          }
+      }
+      else 
+         return -EINVAL;
+      case IIO_CHAN_INFO_ENABLE:
+         st->reg_select = val ? 1 : 0;
+         return 0;
       default: 
          return -EINVAL;
    }
@@ -59,6 +81,7 @@
       .channel = 0,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
 
    {
@@ -66,6 +89,7 @@
       .channel = 1,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
 
    {
@@ -73,6 +97,7 @@
       .channel = 2,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
 
    {
@@ -80,6 +105,7 @@
       .channel = 3,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
 
    {
@@ -87,6 +113,7 @@
       .channel = 4,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
 
    {
@@ -94,6 +121,7 @@
       .channel = 5,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    }
  };
 
@@ -105,9 +133,13 @@
  static int iio_ad5592r_probe(struct spi_device *spi)
  {
     struct iio_dev *indio_dev;
+    struct iio_ad5592r_st *st;
 
-    indio_dev = devm_iio_device_alloc(&spi->dev, 0);
+    indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 
+    st = iio_priv(indio_dev);
+    st->reg_select = 1;
+    memset(st->chan_val, 0, sizeof(st->chan_val));
     indio_dev->name = "iio_ad5592r_s";
     indio_dev->info = &iio_ad5592r_info;
     indio_dev->channels = iio_ad5592r_channels;


### PR DESCRIPTION
## PR Description

Add enable functionality.
Add value selection for ADC channels.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [X] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
