### PR TITLE
drivers: iio: adc: Add proper r/w and enable for AD5592R_S

### DIFF
--- a/drivers/iio/adc/ad5592r_s.c
+++ b/drivers/iio/adc/ad5592r_s.c
@@ -9,136 +9,181 @@
 #include <linux/spi/spi.h>
 #include <linux/iio/iio.h>
 
-static int adc_ad5592r_s_read_raw(struct iio_dev *indio_dev,
-                                struct iio_chan_spec const *chan,
-                                int *val,
-                                int *val2,
-                                long mask)
-{                                
-    switch(mask) {
-        case IIO_CHAN_INFO_RAW:
-            switch(chan->channel){
-                //  AD5592R has 8 channels, but we will only use 6
-                case 0:
-                    *val = 0;
-                    break;
-                case 1:
-                    *val = 1;
-                    break;
-                case 2:
-                    *val = 2;
-                    break;
-                case 3:
-                    *val = 3;
-                    break;
-                case 4:
-                    *val = 4;
-                    break;
-                case 5:
-                    *val = 5;
-                    break;
-                default: 
-                    return -EINVAL;
-            }
-            return IIO_VAL_INT;
-        default:
-            return -EINVAL;
+struct adc_ad5592r_s_st {
+	bool reg_select;
+	int chan_val[6];
+};
 
-    }
+static int adc_ad5592r_s_read_raw(struct iio_dev *indio_dev,
+				  struct iio_chan_spec const *chan, int *val,
+				  int *val2, long mask)
+{
+	struct adc_ad5592r_s_st *st = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		if (!st->reg_select) {
+			switch (chan->channel) {
+			//  AD5592R has 8 channels, but we will only use 6
+			case 0:
+				*val = st->chan_val[0];
+				return IIO_VAL_INT;
+			case 1:
+				*val = st->chan_val[1];
+				return IIO_VAL_INT;
+			case 2:
+				*val = st->chan_val[2];
+				return IIO_VAL_INT;
+			case 3:
+				*val = st->chan_val[3];
+				return IIO_VAL_INT;
+			case 4:
+				*val = st->chan_val[4];
+				return IIO_VAL_INT;
+			case 5:
+				*val = st->chan_val[5];
+				return IIO_VAL_INT;
+			default:
+				return -EINVAL;
+			}
+		} else {
+			return -EINVAL;
+		}
+	case IIO_CHAN_INFO_ENABLE:
+		*val = st->reg_select;
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
+	}
 }
 
 static int adc_ad5592r_s_write_raw(struct iio_dev *indio_dev,
-                                struct iio_chan_spec const *chan,
-                                int val,
-                                int val2,
-                                long mask)
-{                                
-    switch(mask) {
-        case IIO_CHAN_INFO_RAW:
-            switch(chan->channel){
-                case 0:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 1");
-                    break;
-                case 1:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 2");
-                    break;
-                case 2:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 3");
-                    break;
-                case 3:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 4");
-                    break;
-                case 4:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 5");
-                    break;
-                case 5:
-                    dev_info(&indio_dev->dev, "Trying to write to channel 6");
-                    break;
-                default:
-                    dev_info(&indio_dev->dev, "Channel 7 and 8 are not accessible.");
-                    return -EINVAL;
-            }
-            return 0;
-        default:
-            return -EINVAL;
-    }
+				   struct iio_chan_spec const *chan, int val,
+				   int val2, long mask)
+{
+	struct adc_ad5592r_s_st *st = iio_priv(indio_dev);
+	
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+
+		if (!st->reg_select) {
+			switch (chan->channel) {
+			case 0:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 0");
+				st->chan_val[0] = val;
+				break;
+			case 1:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 1");
+				st->chan_val[1] = val;
+				break;
+			case 2:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 2");
+				st->chan_val[2] = val;
+				break;
+			case 3:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 3");
+				st->chan_val[3] = val;
+				break;
+			case 4:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 4");
+				st->chan_val[4] = val;
+				break;
+			case 5:
+				dev_info(&indio_dev->dev,
+					 "Trying to write to channel 5");
+				st->chan_val[5] = val;
+				break;
+			default:
+				dev_info(&indio_dev->dev,
+					 "Channel 7 and 8 are not accessible.");
+				return -EINVAL;
+			}
+			return 0;
+		} else {
+			return -EINVAL;
+		}
+
+	case IIO_CHAN_INFO_ENABLE:
+		st->reg_select = val ? 1 : 0;
+		return 0;
+
+	default:
+		return -EINVAL;
+	}
 }
 
 static const struct iio_chan_spec adc_ad5592r_s_channels[] = {
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 0,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 1,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 2,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 3,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 4,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    },
-    {
-        .type = IIO_VOLTAGE,
-        .channel = 5,
-        .indexed = 1,
-        .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
-    }
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 0,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 1,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 2,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 3,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 4,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	},
+	{
+		.type = IIO_VOLTAGE,
+		.channel = 5,
+		.indexed = 1,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE),
+	}
 };
 
 static const struct iio_info ad5592r_s_info = {
-    .read_raw = &adc_ad5592r_s_read_raw,
-    .write_raw = &adc_ad5592r_s_write_raw
+	.read_raw = &adc_ad5592r_s_read_raw,
+	.write_raw = &adc_ad5592r_s_write_raw
 };
 
-static int ad5592r_s_probe(struct spi_device *spi) {
-    struct iio_dev *indio_dev;
+static int ad5592r_s_probe(struct spi_device *spi)
+{
+	struct iio_dev *indio_dev;
+	struct adc_ad5592r_s_st *st;
 
-    indio_dev = devm_iio_device_alloc(&spi->dev, 0);
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 
-    indio_dev->name = "ad5592r_s";
-    indio_dev->info = &ad5592r_s_info;
-    indio_dev->channels = adc_ad5592r_s_channels;
-    indio_dev->num_channels = 6;
+	st = iio_priv(indio_dev);
+	st->reg_select = 1;
+	memset(st->chan_val, 0, sizeof(sizeof(st->chan_val)));
 
-    return devm_iio_device_register(&spi->dev, indio_dev);
+	indio_dev->name = "ad5592r_s";
+	indio_dev->info = &ad5592r_s_info;
+	indio_dev->channels = adc_ad5592r_s_channels;
+	indio_dev->num_channels = ARRAY_SIZE(adc_ad5592r_s_channels);
+
+	return devm_iio_device_register(&spi->dev, indio_dev);
 }
 
 static struct spi_driver ad5592r_s_driver = {
@@ -147,7 +192,7 @@ static struct spi_driver ad5592r_s_driver = {
     },
     .probe = ad5592r_s_probe,
 };
-module_spi_driver(ad5592r_s_driver)
+module_spi_driver(ad5592r_s_driver);
 
 MODULE_AUTHOR("Alexandru Iordache");
 MODULE_DESCRIPTION("Analog Devices AD5592R ADC Summer School");


### PR DESCRIPTION
## PR Description

Removed mock read/write values and implemented actual read/write functionality for raw values and enable.
Added struct for the enable and channel value array, with proper initialization in the probe function.
Tested on CORAZ7S board.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
