### PR TITLE
drivers: iio: adc: Added private state structure and channel enable for cora driver

### DIFF
--- a/drivers/iio/adc/ad5592r_s.c
+++ b/drivers/iio/adc/ad5592r_s.c
@@ -9,126 +9,171 @@
  #include <linux/spi/spi.h>
  #include <linux/iio/iio.h>
 
- static int iio_adc_cora_read_raw(struct iio_dev *indio_dev, 
-                              struct iio_chan_spec const *chan, 
-                              int *val, 
-                              int *val2, 
-                              long mask)
-{
-    switch(mask) {
-      case IIO_CHAN_INFO_RAW:
-            if (chan->channel == 0)
-               *val = 67;
-            else if (chan->channel == 1)
-               *val = 76;
-            else if (chan->channel == 2)
-               *val = 85;
-            else if (chan->channel == 3)
-               *val = 94;
-            else if (chan->channel == 4)
-               *val = 103;
-            else if (chan->channel == 5)
-               *val = 112;
-            return IIO_VAL_INT;
+struct iio_adc_cora_st {
+    int reg_select;
+    int chan_val[6];
+};
 
-      default: 
+static int iio_adc_cora_read_raw(struct iio_dev *indio_dev,
+                                struct iio_chan_spec const *chan,
+                                int *val,
+                                int *val2,
+                                long mask) {
+
+    struct iio_adc_cora_st *st = iio_priv(indio_dev);
+
+    switch(mask) {
+        case IIO_CHAN_INFO_RAW:
+            if(!st->reg_select) {
+                if (chan->channel == 0)
+                    *val = st->chan_val[0];
+                else if (chan->channel == 1)
+                    *val = st->chan_val[1];
+                else if (chan->channel == 2)
+                    *val = st->chan_val[2];
+                else if (chan->channel == 3)
+                    *val = st->chan_val[3];
+                else if (chan->channel == 4)
+                    *val = st->chan_val[4];
+                else if (chan->channel == 5)
+                    *val = st->chan_val[5];
+                return IIO_VAL_INT;
+            }
+            else 
+                return -EINVAL;
+        case IIO_CHAN_INFO_ENABLE:
+            *val = st->reg_select;
+            return IIO_VAL_INT;
+        default: 
             return -EINVAL;
     }
 }
 
- static int iio_adc_cora_write_raw(struct iio_dev *indio_dev, 
-                              struct iio_chan_spec const *chan, 
-                              int val, 
-                              int val2, 
-                              long mask)      
-{
-   switch(mask) {
-      case IIO_CHAN_INFO_RAW:
-            if (chan->channel == 0)
-               dev_info(&indio_dev->dev, "Trying to write to channel 0: %d\n", val);
-            else if (chan->channel == 1)
-               dev_info(&indio_dev->dev, "Trying to write to channel 1: %d\n", val);
-            else if (chan->channel == 2)
-               dev_info(&indio_dev->dev, "Trying to write to channel 2: %d\n", val);
-            else if (chan->channel == 3)
-               dev_info(&indio_dev->dev, "Trying to write to channel 3: %d\n", val);
-            else if (chan->channel == 4)
-               dev_info(&indio_dev->dev, "Trying to write to channel 4: %d\n", val);
-            else if (chan->channel == 5)
-               dev_info(&indio_dev->dev, "Trying to write to channel 5: %d\n", val);
-            return 0;
+static int iio_adc_cora_write_raw(struct iio_dev *indio_dev,
+                                struct iio_chan_spec const *chan,
+                                int val,
+                                int val2,
+                                long mask) {
 
-      default:
-         return -EINVAL; 
+    struct iio_adc_cora_st *st = iio_priv(indio_dev);
+
+    switch(mask) {
+        case IIO_CHAN_INFO_RAW:
+            if(!st->reg_select) {
+                if (chan->channel == 0) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 0: %d\n", val);
+                    st->chan_val[0] = val;
+                }
+                else if (chan->channel == 1) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 1: %d\n", val);
+                    st->chan_val[1] = val;
+                }
+                else if (chan->channel == 2) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 2: %d\n", val);
+                    st->chan_val[2] = val;
+                }
+                else if (chan->channel == 3) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 3: %d\n", val);
+                    st->chan_val[3] = val;
+                }
+                else if (chan->channel == 4) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 4: %d\n", val);
+                    st->chan_val[4] = val;
+                }
+                else if (chan->channel == 5) {
+                    dev_info(&indio_dev->dev, "Trying to write to channel 5: %d\n", val);
+                    st->chan_val[5] = val;
+                }
+                return 0;                
+            }
+            else
+                return -EINVAL;
+        case IIO_CHAN_INFO_ENABLE:
+            st->reg_select = val ? 1 : 0;
+            return 0;
+        default:
+            return -EINVAL;
    }
 }
 
- static const struct iio_chan_spec iio_adc_cora_channels[] = {
+static const struct iio_chan_spec iio_adc_cora_channels[] = {
    {
       .type = IIO_VOLTAGE,
       .channel = 0,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
    {
       .type = IIO_VOLTAGE,
       .channel = 1,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
    {
       .type = IIO_VOLTAGE,
       .channel = 2,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
    {
       .type = IIO_VOLTAGE,
       .channel = 3,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
    {
       .type = IIO_VOLTAGE,
       .channel = 4,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    },
    {
       .type = IIO_VOLTAGE,
       .channel = 5,
       .indexed = 1,
       .info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+      .info_mask_shared_by_all = BIT(IIO_CHAN_INFO_ENABLE)
    }
  };
 
-  static const struct iio_info iio_adc_cora_info = {
+ static const struct iio_info iio_adc_cora_info = {
    .read_raw = &iio_adc_cora_read_raw,
    .write_raw = &iio_adc_cora_write_raw
- };
+};
 
- static int iio_adc_probe(struct spi_device *spi){
+static int iio_adc_probe(struct spi_device *spi){
 
     struct iio_dev *indio_dev;
-    
-    indio_dev = devm_iio_device_alloc(&spi->dev, 0);
+    struct iio_adc_cora_st *st;
+
+    indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
+
+    st = iio_priv(indio_dev);
+    st->reg_select = 1;
+    memset(st->chan_val, 0, sizeof(st->chan_val));
 
     indio_dev->name = "ad5592r_s";
     indio_dev->info = &iio_adc_cora_info;
     indio_dev->channels = iio_adc_cora_channels;
-    indio_dev->num_channels = 6;
+    indio_dev->num_channels = ARRAY_SIZE(iio_adc_cora_channels);
 
     return devm_iio_device_register(&spi->dev, indio_dev);
- }
+}
 
- static struct spi_driver iio_adc_driver = {
+static struct spi_driver iio_adc_driver = {
     .driver = {
         .name = "ad5592r_s"
     },
     .probe = iio_adc_probe
- };
- module_spi_driver(iio_adc_driver);
+};
+
+module_spi_driver(iio_adc_driver);
  
- MODULE_AUTHOR("Moldovan Flavius <flaviuss3035@gmail.com>");
- MODULE_DESCRIPTION("Analog Devices IIO CORA Summer School");
- MODULE_LICENSE("GPL v2");
+MODULE_AUTHOR("Moldovan Flavius <flaviuss3035@gmail.com>");
+MODULE_DESCRIPTION("Analog Devices IIO CORA Summer School");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
## PR Description

Added iio_adc_cora_st private state structure to hold channel values and enable status for 6 channels. 
Added IIO_CHAN_INFO_ENABLE handling to read_raw and write_raw callbacks to control device state. 
Added dynamic channel value storage for channels 0 to 5 in private state during raw write operations. 
Added array initialization for channels and updated channel count calculation using ARRAY_SIZE.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
